### PR TITLE
fix user check before access _id for request params

### DIFF
--- a/src/components/Notes.vue
+++ b/src/components/Notes.vue
@@ -368,7 +368,7 @@ export default {
     axios
       .get('http://localhost:3000/getNotes', {
         // eslint-disable-next-line no-underscore-dangle
-        params: { userId: this.$store.state.user._id },
+        params: { userId: this.$store.state.user ? this.$store.state.user._id : '' },
         headers: {
           Authorization: `Bearer ${this.$store.state.token}`,
         },


### PR DESCRIPTION
Check if user object exist before trying to access its _id property necessary to send with `getNotes` axios request.
This were preventing vue router to load correctly.